### PR TITLE
♻️ Api: /process-image q변수로 받으면 해당하는 data 반환하도록 수정

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -8,11 +8,13 @@ from fastapi import FastAPI, Path
 from fastapi.responses import JSONResponse
 from pathlib import Path as PPath
 from fastapi import Query
+from typing import Dict, Any, List
 
 load_dotenv()
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://43.202.177.63:8080")
 S3_URL = os.getenv("S3_URL", "https://s3-eyedia.s3.ap-northeast-2.amazonaws.com")
+FAISS_JSON_PATH = PPath("./data/faiss/met_structured_with_objects.json")  # 실제 경로로 조정
 
 app = FastAPI()
 
@@ -54,6 +56,69 @@ def send_metadata_to_backend(painting_id : int):
     resp = requests.post(url, json=payload, timeout=10)
     resp.raise_for_status()
     return payload
+VALID_QUADS = {"Q1", "Q2", "Q3", "Q4"}
+
+@lru_cache(maxsize=1)
+def _load_faiss_json() -> Dict[int, Dict[str, Any]]:
+    """
+    JSON을 로드하고 full_image_id(=painting_id)로 바로 접근 가능하도록 인덱싱.
+    반환 형태: { full_image_id: { ..원본 json.. }, ... }
+    """
+    if not FAISS_JSON_PATH.exists():
+        raise FileNotFoundError(f"FAISS JSON not found: {FAISS_JSON_PATH}")
+
+    with FAISS_JSON_PATH.open("r", encoding="utf-8") as f:
+        # 파일이 단일 객체 하나가 아니라 여러 항목 리스트일 수도 있어 대비
+        data = json.load(f)
+
+    # 케이스 A) 파일 구조가 "하나의 작품"만 담긴 단일 객체
+    if isinstance(data, dict) and "full_image_id" in data:
+        return {int(data["full_image_id"]): data}
+
+    # 케이스 B) 여러 작품을 담은 리스트
+    if isinstance(data, list):
+        indexed = {}
+        for item in data:
+            if isinstance(item, dict) and "full_image_id" in item:
+                indexed[int(item["full_image_id"])] = item
+        return indexed
+
+    raise ValueError("Unexpected FAISS JSON structure. Expect dict with full_image_id or list of such dicts.")
+
+
+def _extract_quadrant_crops(painting_id: int, q: str) -> List[Dict[str, Any]]:
+    """
+    해당 painting의 crops 중 quadrant_ratios[q] > 0 인 것만 추출하여
+    ratio 내림차순으로 정렬해 반환.
+    """
+    q = (q or "").upper().strip()
+    if q not in VALID_QUADS:
+        raise ValueError(f"q must be one of {sorted(VALID_QUADS)} (got: {q!r})")
+
+    db = _load_faiss_json()
+    item = db.get(int(painting_id))
+    if not item:
+        # painting이 없으면 빈 리스트
+        return []
+
+    crops = item.get("crops", []) or []
+    results = []
+    for c in crops:
+        ratios = (c.get("quadrant_ratios") or {})
+        ratio = float(ratios.get(q, 0.0) or 0.0)
+        if ratio > 0.0:
+            results.append({
+                "cropId": c.get("crop_id"),
+                "cropPath": c.get("crop_path"),
+                "cropDescription": c.get("crop_description"),
+                "primaryQuadrant": c.get("primary_quadrant"),
+                "quadrant": q,
+                "ratio": ratio
+            })
+
+    # 비율 내림차순
+    results.sort(key=lambda x: x["ratio"], reverse=True)
+    return results
 
 # 백엔드: WebSocket Push용 엔드포인트 호출 - 그림 인식
 def push_painting_detected(painting_id : int):
@@ -67,22 +132,49 @@ def push_painting_detected(painting_id : int):
         print(f"[WARN] WebSocket push 실패: {e}")
 
 # 백엔드: WebSocket Push용 엔드포인트 호출 - 영역 인식
-def push_painting_area_detected(painting_id: int, q: str = None):
+def push_painting_area_detected(painting_id: int, q: str | list[str] = None, top_k: int | None = None) -> bool:
+    """
+    painting_id와 여러 사분면(q)을 받아 해당 crop 리스트를 구성해 백엔드로 POST.
+    q는 문자열 하나("Q1") 또는 문자열 리스트(["Q1","Q2"]) 모두 가능.
+    """
     try:
-        # 영역 정보 포함 → JSON 객체 전송
-        # Todo: 백엔드와 맞춰야 함. 백엔드 dto 수정 필요
-        payload = {
-            "artId": painting_id,
-            "q": q
-        }
-        url = f"{BACKEND_URL}/api/v1/events/detect-area"
+        # q를 리스트로 정규화
+        if isinstance(q, str):
+            q_list = [q.upper().strip()]
+        elif isinstance(q, list):
+            q_list = [str(x).upper().strip() for x in q if x]
+        else:
+            q_list = []
 
-        res = requests.post(url, json=payload)
+        # 유효한 Q만 필터링
+        q_list = [x for x in q_list if x in VALID_QUADS]
+
+        crops_all = []
+        for q_item in q_list:
+            crops = _extract_quadrant_crops(painting_id, q_item)
+            if top_k is not None and top_k > 0:
+                crops = crops[:top_k]
+
+            # 각 crop에 현재 q 추가 (겹치는 경우도 그대로 허용)
+            for c in crops:
+                crops_all.append({**c, "quadrant": q_item})
+
+        payload = {
+            "artId": int(painting_id),
+            "q": q_list,
+            "list": crops_all
+        }
+        
+        url = f"{BACKEND_URL}/api/v1/events/detect-area"
+        print(f"[Test] 응답 결과 확인용: {url} (artId={painting_id}, q={q_list}, count={len(crops_all)}, data={payload})")
+        res = requests.post(url, json=payload, timeout=10)
         res.raise_for_status()
-        print(f"[✅] WebSocket push 성공: {url}")
+        print(f"[✅] WebSocket push 성공: {url} (artId={painting_id}, q={q_list}, count={len(crops_all)})")
+        return True
 
     except Exception as e:
         print(f"[WARN] WebSocket push 실패: {e}")
+        return False
 
 # FastAPI 엔드포인트
 @app.post("/process-image")


### PR DESCRIPTION
기존에는 Q1 전송을 고정했지만 새로운 백엔드 api 와 연결 후, 데이터 리스트 반환하도록 수정

Closes #72 

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

- 기존에는 Q1 전송을 고정했지만 새로운 백엔드 api 와 연결 후, 데이터 리스트 반환하도록 수정
### 기능 설명

## /process-image 엔드포인트 분기화
http://localhost:8000/process-image?art_id=200002
-> {BACKEND_URL}/api/v1/events/detect

http://localhost:8000/process-image?art_id=200002&q=Q3
-> {BACKEND_URL}/api/v1/events/detect-area

요청 파라미터 (art_id, q)

성공 응답(JSON 구조: 메타데이터 + result=success)

실패 응답(500 에러 등)

- 모델 -> 백엔드  Payload 구조 명세

`{'artId': 200002, '
	q': ['Q3'], // 응시한 영역
	
	'list': [
		{'cropId': '200002_crop1', 
		'cropPath': './data/crops/200002_crop1.jpg', 
		'cropDescription': '모네의 아들. 노란색 모자를 쓰고 풀 속에 서있다.', 
		'primaryQuadrant': 'Q3', 'quadrant': 'Q3', 'ratio': 1.0
		}, 
		{'cropId': '200002_crop0', 
		'cropPath': './data/crops/200002_crop0.jpg', 
		'cropDescription': '모네의 아내. 양산을 쓰고 푸른 드레스를 입고있다. 모네를 쳐다보고 있는것일까?', 
		'primaryQuadrant': 'Q2', 'quadrant': 'Q3', 'ratio': 0.1337465478816611}
		]
	}`

### ⏰ 임시 데드라인

2025-09-22

### 📌 필요 이유 (선택)

모델 -> 백엔드로 응답 전송 분기


### 📎 추가 내용 (선택)

- [x] click.py와 main.py 병합
- [x] /process-image q응답에 따른 백엔드 api 호출 분기
- [x] faiss db에서 해당하는 q검색하여 리스트 반환

## 💡 해결한 이슈 목록

- #72 


## ✅ 변경사항

- main.py

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

